### PR TITLE
feat(infra): enable cors apigateway

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           export PATH="${pulumi_3_67_0}:$PATH"
 
           ln -fs $NODE_PATH node_modules
+          ln -fs $NODE_PATH infra/aws/node_modules
         '';
       };
   };

--- a/infra/aws/index.ts
+++ b/infra/aws/index.ts
@@ -1,5 +1,5 @@
-import * as apigateway from "@pulumi/aws-apigateway";
 import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as CryptoJS from "crypto-js";
 import type { APIGatewayProxyEvent } from "aws-lambda";
@@ -15,6 +15,11 @@ interface Payload {
   host: string;
   inputs: HTMLAttribute[][];
   path: string;
+}
+
+interface LambdaResponse {
+  statusCode: number;
+  headers?: Record<string, string>;
 }
 
 const dynamoTable: Table = new aws.dynamodb.Table("toe_enumerator", {
@@ -33,7 +38,7 @@ const dynamoTable: Table = new aws.dynamodb.Table("toe_enumerator", {
       {
         hashKey: "hk",
         name: "gsi-1",
-        projectionType: "INCLUDE",
+        projectionType: "ALL",
         rangeKey: "rk",
         readCapacity: 10,
         writeCapacity: 10,
@@ -47,51 +52,76 @@ const dynamoTable: Table = new aws.dynamodb.Table("toe_enumerator", {
   // A Lambda function to invoke
   lambdaFn = new aws.lambda.CallbackFunction("enumerator_fn", {
     callback: async (event: APIGatewayProxyEvent) => {
-      const { body } = event;
+      let response: LambdaResponse;
 
-      if (body !== null) {
-        const parsedBody = JSON.parse(body) as Payload,
-          { host, inputs, path } = parsedBody,
-          writeRequests: DocumentClient.WriteRequests = [];
+      if (event.httpMethod.toLowerCase() === "options") {
+        response = {
+          headers: {
+            "Access-Control-Allow-Headers": "Content-Type",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "OPTIONS,POST",
+          },
+          statusCode: 200,
+        };
+      } else {
+        let { body } = event;
 
-        inputs.forEach((input: HTMLAttribute[]) => {
-          const item: Record<string, string> = {};
+        if (body !== null) {
+          if (event.isBase64Encoded) {
+            body = Buffer.from(body, "base64").toString("binary");
+          }
 
-          input.forEach((attribute: HTMLAttribute) => {
-            item[attribute.name] = attribute.value;
+          const parsedBody = JSON.parse(body) as Payload,
+            { host, inputs, path } = parsedBody,
+            writeRequests: DocumentClient.WriteRequests = [];
+
+          inputs.forEach((input: HTMLAttribute[]) => {
+            const item: Record<string, string> = {};
+
+            input.forEach((attribute: HTMLAttribute) => {
+              item[attribute.name] = attribute.value;
+            });
+
+            const identifier: string =
+              item["name"] ||
+              item["id"] ||
+              item["placeholder"] ||
+              CryptoJS.SHA256(JSON.stringify(input)).toString(CryptoJS.enc.Hex);
+
+            item["hk"] = `HOST#${host}#PATH#${path}`;
+            item["rk"] = `TAG#${item["tagname"]}#IDENTIFIER#${identifier}`;
+            writeRequests.push({
+              PutRequest: {
+                Item: item,
+              },
+            });
           });
 
-          const identifier: string =
-            item["name"] ||
-            item["id"] ||
-            item["placeholder"] ||
-            CryptoJS.SHA256(JSON.stringify(input)).toString(CryptoJS.enc.Hex);
+          const dynamoClient = new aws.sdk.DynamoDB.DocumentClient();
+          await dynamoClient
+            .batchWrite({
+              RequestItems: {
+                [dynamoTable.name.get()]: writeRequests,
+              },
+            })
+            .promise();
+        }
 
-          item["hk"] = `HOST#${host}#PATH#${path}`;
-          item["pk"] = `TAG#${item["tagname"]}#IDENTIFIER#${identifier}`;
-          writeRequests.push({
-            PutRequest: {
-              Item: item,
-            },
-          });
-        });
-
-        const dynamoClient = new aws.sdk.DynamoDB.DocumentClient();
-        await dynamoClient
-          .batchWrite({
-            RequestItems: {
-              [dynamoTable.name.get()]: writeRequests,
-            },
-          })
-          .promise();
+        response = {
+          headers: { "Access-Control-Allow-Origin": "*" },
+          statusCode: 200,
+        };
       }
 
-      return { statusCode: 200 };
+      return response;
     },
   }),
   // A REST API to route requests to HTML content and the Lambda function
-  restApi: apigateway.RestAPI = new apigateway.RestAPI("enumerator_api", {
-    routes: [{ path: "/", method: "POST", eventHandler: lambdaFn }],
+  restApi = new awsx.classic.apigateway.API("enumerator_api", {
+    routes: [
+      { path: "/", method: "OPTIONS", eventHandler: lambdaFn },
+      { path: "/", method: "POST", eventHandler: lambdaFn },
+    ],
   });
 
 // The URL at which the REST API will be served.

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -5,8 +5,8 @@
 	},
 	"dependencies": {
 		"@pulumi/aws": "5.39.0",
-		"@pulumi/aws-apigateway": "1.0.1",
 		"@pulumi/awsx": "1.0.2",
-		"@pulumi/pulumi": "3.67.0"
+		"@pulumi/pulumi": "3.67.0",
+		"crypto-js": "4.1.1"
 	}
 }

--- a/node-packages.nix
+++ b/node-packages.nix
@@ -351,15 +351,6 @@
         sha512 = "jDfWgCiX6DKrTbb+41zQ142+GJcg6Shhr4IAImK78oSMZdqw6Zur2CvaRI5YaZaNVGlFLLK6w0thxUZgbeM1AA==";
       };
     };
-    "@pulumi/aws-apigateway-1.0.1" = {
-      name = "_at_pulumi_slash_aws-apigateway";
-      packageName = "@pulumi/aws-apigateway";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@pulumi/aws-apigateway/-/aws-apigateway-1.0.1.tgz";
-        sha512 = "pDQE42uuLaHboa76zxHPq3n75ymMzKdamlL63RjKfBBdK6fCoJW46ipSUZ+fuOHHmjufCXMCQT9ZW7mIp4OuKg==";
-      };
-    };
     "@pulumi/awsx-1.0.2" = {
       name = "_at_pulumi_slash_awsx";
       packageName = "@pulumi/awsx";
@@ -3025,7 +3016,6 @@
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@pulumi/aws-5.39.0"
-      sources."@pulumi/aws-apigateway-1.0.1"
       sources."@pulumi/awsx-1.0.2"
       sources."@pulumi/docker-3.6.1"
       (sources."@pulumi/pulumi-3.67.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
 			"name": "enumerator",
 			"dependencies": {
 				"@pulumi/aws": "5.39.0",
-				"@pulumi/aws-apigateway": "1.0.1",
 				"@pulumi/awsx": "1.0.2",
 				"@pulumi/pulumi": "3.67.0",
 				"@types/aws-lambda": "8.10.115",
@@ -477,16 +476,6 @@
 				"mime": "^2.0.0",
 				"read-package-tree": "^5.2.1",
 				"resolve": "^1.7.1"
-			}
-		},
-		"node_modules/@pulumi/aws-apigateway": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@pulumi/aws-apigateway/-/aws-apigateway-1.0.1.tgz",
-			"integrity": "sha512-pDQE42uuLaHboa76zxHPq3n75ymMzKdamlL63RjKfBBdK6fCoJW46ipSUZ+fuOHHmjufCXMCQT9ZW7mIp4OuKg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"@pulumi/aws": "^5.16.2",
-				"@pulumi/pulumi": "^3.42.0"
 			}
 		},
 		"node_modules/@pulumi/awsx": {
@@ -4042,15 +4031,6 @@
 				"mime": "^2.0.0",
 				"read-package-tree": "^5.2.1",
 				"resolve": "^1.7.1"
-			}
-		},
-		"@pulumi/aws-apigateway": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@pulumi/aws-apigateway/-/aws-apigateway-1.0.1.tgz",
-			"integrity": "sha512-pDQE42uuLaHboa76zxHPq3n75ymMzKdamlL63RjKfBBdK6fCoJW46ipSUZ+fuOHHmjufCXMCQT9ZW7mIp4OuKg==",
-			"requires": {
-				"@pulumi/aws": "^5.16.2",
-				"@pulumi/pulumi": "^3.42.0"
 			}
 		},
 		"@pulumi/awsx": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"@typescript-eslint/eslint-plugin": "5.59.5",
 		"@typescript-eslint/parser": "5.59.5",
 		"@pulumi/aws": "5.39.0",
-		"@pulumi/aws-apigateway": "1.0.1",
 		"@pulumi/awsx": "1.0.2",
 		"@pulumi/pulumi": "3.67.0",
 		"crypto-js": "4.1.1",

--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -35,7 +35,7 @@ function getToEInputs(): HTMLAttribute[][] {
   return toeInputs;
 }
 
-void fetch("http://127.0.0.1:5000/", {
+void fetch("https://s8du5jy3c2.execute-api.eu-central-1.amazonaws.com/stage/", {
   method: "post",
   body: JSON.stringify({
     host: window.location.hostname,


### PR DESCRIPTION
- Accept HTTP method OPTIONS so the CORS preflight request can succeed and the request can be sent.
- For some reason, the payload is base64 encoded in the Lambda, changing the binaryMediaTypes of the API Gateway did not fix this, so just decode the input before processing.
- The attempt to change the binaryMediaTypes used a library different from aws-apigateway, so this library was removed.