### PR TITLE
feat(cross): add event listener to front

### DIFF
--- a/infra/aws/index.ts
+++ b/infra/aws/index.ts
@@ -130,7 +130,6 @@ const processInputs = (
 };
 
 const lambdaFn = new aws.lambda.CallbackFunction("enumerator_fn", {
-  memorySize: 512,
   callbackFactory: () => {
     let dynamoClient = new aws.sdk.DynamoDB.DocumentClient();
 

--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -35,12 +35,17 @@ function getToEInputs(): HTMLAttribute[][] {
   return toeInputs;
 }
 
-void fetch("https://s8du5jy3c2.execute-api.eu-central-1.amazonaws.com/stage/", {
-  method: "post",
-  body: JSON.stringify({
-    host: window.location.hostname,
-    inputs: getToEInputs(),
-    path: window.location.pathname,
-  }),
-  headers: { "Content-Type": "application/json" },
+document.addEventListener("DOMContentLoaded", () => {
+  void fetch(
+    "https://s8du5jy3c2.execute-api.eu-central-1.amazonaws.com/stage/",
+    {
+      method: "post",
+      body: JSON.stringify({
+        host: window.location.hostname,
+        inputs: getToEInputs(),
+        path: window.location.pathname,
+      }),
+      headers: { "Content-Type": "application/json" },
+    }
+  );
 });


### PR DESCRIPTION
- Add event listener to front script so it runs after the DOM is loaded. Otherwise, it may not find any inputs.
- Use default RAM size for Lambda since performance improvements are not so drastic.