### PR TITLE
feat(cross): take inputs belonging to forms

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,10 +53,11 @@ steps:
       - echo +++ Build code
       - cd infra/aws
       - export PULUMI_REST_API_URL="$(pulumi stack output url --stack dev)"
+      - export S3_BUCKET="$(pulumi stack output s3BucketName --stack dev)"
       - cd ../../src/
       - cat enumerator.ts | envsubst '$$PULUMI_REST_API_URL' > new
       - mv new enumerator.ts
       - tsc
       - echo --- Uploading to AWS
-      - aws s3 cp dist/enumerator.js s3://fluid.enumerates/enumerator.js --sse
+      - aws s3 cp dist/enumerator.js "s3://$$S3_BUCKET/enumerator.js" --sse
       - echo +++ Success

--- a/infra/aws/index.ts
+++ b/infra/aws/index.ts
@@ -292,4 +292,5 @@ const restApi = new awsx.classic.apigateway.API("enumerator-api", {
 });
 
 // The URL at which the REST API will be served.
-export const { url } = restApi;
+export const { url } = restApi,
+  s3BucketName = s3Bucket.id;

--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -17,9 +17,7 @@ function stringToHash(string: string): number {
   return hash;
 }
 
-function parseHTMLAttributes(
-  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-): HTMLAttribute[] {
+function parseHTMLAttributes(element: HTMLElement): HTMLAttribute[] {
   const parsedAttributes: HTMLAttribute[] = [
     { name: "tagname", value: element.tagName },
   ];
@@ -36,20 +34,25 @@ function parseHTMLAttributes(
 }
 
 function getToEInputs(): HTMLAttribute[][] {
-  const inputs: NodeListOf<HTMLInputElement> =
-      document.querySelectorAll("input"),
-    textareas: NodeListOf<HTMLTextAreaElement> =
-      document.querySelectorAll("textarea"),
-    selects: NodeListOf<HTMLSelectElement> =
-      document.querySelectorAll("select"),
-    toeInputs: HTMLAttribute[][] = [];
+  const toeInputs: HTMLAttribute[][] = [];
 
-  for (const htmlElements of [inputs, textareas, selects]) {
-    htmlElements.forEach((htmlElement) => {
-      const parsedElement = parseHTMLAttributes(htmlElement);
+  for (const elementType of ["input", "select", "textarea"]) {
+    const elements = document.evaluate(
+      `//form//${elementType}`,
+      document,
+      null,
+      XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+      null
+    );
 
-      toeInputs.push(parsedElement);
-    });
+    let element = elements.iterateNext();
+    while (element) {
+      if (element.nodeType === Node.ELEMENT_NODE) {
+        const parsedElement = parseHTMLAttributes(element as HTMLElement);
+        toeInputs.push(parsedElement);
+      }
+      element = elements.iterateNext();
+    }
   }
 
   return toeInputs;


### PR DESCRIPTION
- Instead of querying all the inputs/selectors/textareas in the whole document, only take into account those that are children of a form element. This avoids false inputs from beign enumerated.
- Allow Pulumi to generate the name for the S3 bucket.