### PR TITLE
feat(job): upload script only when it changes

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eou pipefail
+
+while read -r changed_file;
+do
+  if [[ "${changed_file}" == src/enumerator.ts ]];
+  then
+    cat .buildkite/upload_script.yml
+  fi
+done < <(git diff HEAD~1 --name-only)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,7 @@
 steps:
+  - label: ":pipeline: Upload Pipeline Spec"
+    command: .buildkite/pipeline.sh | buildkite-agent pipeline upload
+
   - label: ":lint-roller: Linter"
     branches: "!main"
     command:
@@ -42,6 +45,7 @@ steps:
       - echo --- Success
 
   - label: ":pulumi: Deploy AWS"
+    key: deploy_pulumi
     branches: main
     command:
       - echo --- Load environment
@@ -51,23 +55,3 @@ steps:
       - cd infra/aws
       - pulumi up --stack dev --non-interactive --yes
       - echo --- Success
-
-  - wait
-
-  - label: ":s3: Upload script to AWS"
-    branches: main
-    command:
-      - echo --- Load environment
-      - direnv allow
-      - eval "$(direnv export bash)"
-      - echo +++ Build code
-      - cd infra/aws
-      - export PULUMI_REST_API_URL="$(pulumi stack output url --stack dev)"
-      - export S3_BUCKET="$(pulumi stack output s3BucketName --stack dev)"
-      - cd ../../src/
-      - cat enumerator.ts | envsubst '$$PULUMI_REST_API_URL' > new
-      - mv new enumerator.ts
-      - tsc
-      - echo --- Uploading to AWS
-      - aws s3 cp dist/enumerator.js "s3://$$S3_BUCKET/enumerator.js" --sse
-      - echo +++ Success

--- a/.buildkite/upload_script.yml
+++ b/.buildkite/upload_script.yml
@@ -1,0 +1,20 @@
+steps:
+  - label: ":s3: Upload script to AWS"
+    branches: main
+    command:
+      - echo --- Load environment
+      - direnv allow
+      - eval "$(direnv export bash)"
+      - echo +++ Build code
+      - cd infra/aws
+      - export PULUMI_REST_API_URL="$(pulumi stack output url --stack dev)"
+      - export S3_BUCKET="$(pulumi stack output s3BucketName --stack dev)"
+      - cd ../../src/
+      - cat enumerator.ts | envsubst '$$PULUMI_REST_API_URL' > new
+      - mv new enumerator.ts
+      - tsc
+      - echo --- Uploading to AWS
+      - aws s3 cp dist/enumerator.js "s3://$$S3_BUCKET/enumerator.js" --sse
+      - echo +++ Success
+    depends_on:
+      - deploy_pulumi

--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -9,8 +9,8 @@ function stringToHash(string: string): number {
   let hash = 0;
 
   for (let i = 0; i < string.length; i++) {
-    const char = string.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
+    const charCode = string.charCodeAt(i);
+    hash = (hash << 5) - hash + charCode;
     hash = hash & hash;
   }
 


### PR DESCRIPTION
- Build Buildkite pipeline dynamically so the script upload only happens when the script changes.
- This way, we avoid having to generate a new SRI hash for every commit to the repository.