### PR TITLE
refac(job): change pipeline upload label

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,10 +2,12 @@
 
 set -eou pipefail
 
+echo "steps:"
+
 while read -r changed_file;
 do
   if [[ "${changed_file}" == src/enumerator.ts ]];
   then
-    cat .buildkite/upload_script.yml
+    buildkite-agent pipeline upload .buildkite/upload_script.yml
   fi
 done < <(git diff HEAD~1 --name-only)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
-  - label: ":pipeline: Upload Pipeline Spec"
-    command: .buildkite/pipeline.sh | buildkite-agent pipeline upload
+  - label: ":pipeline: Upload Dynamic Steps"
+    command: .buildkite/pipeline.sh
 
   - label: ":lint-roller: Linter"
     branches: "!main"


### PR DESCRIPTION
- Make the label more clear.
- Test whether the dynamic logic is working.
- Use the YAML file instead of STDIN to upload dynamic steps.