### PR TITLE
feat(front): use xpath as unique identifier

### DIFF
--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -3,25 +3,63 @@ interface HTMLAttribute {
   value: string;
 }
 
+interface ToEInputs {
+  cookies: string[];
+  forms: HTMLAttribute[][];
+}
+
 // Global variable used in SPAs to keep track of enumerated inputs
 // and avoid doing unnecessary calls to the enumerator API
-// const fAToEInputs: number[] = [];
+const fAToEInputs: number[] = [];
 
-// function stringToHash(string: string): number {
-//   let hash = 0;
+function stringToHash(string: string): number {
+  let hash = 0;
 
-//   for (let i = 0; i < string.length; i++) {
-//     const char = string.charCodeAt(i);
-//     hash = (hash << 5) - hash + char;
-//     hash = hash & hash;
-//   }
+  for (let i = 0; i < string.length; i++) {
+    const char = string.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
 
-//   return hash;
-// }
+  return hash;
+}
+
+function getXPath(element: Element): string {
+  if (element.id !== "") {
+    return `//*[@id='${element.id}']`;
+  }
+  if (element.tagName.toLowerCase() === "html") {
+    return "/html";
+  }
+
+  const parent = element.parentElement;
+  if (parent !== null) {
+    const siblings = parent.children;
+    let idx = 1;
+
+    if (siblings.length > 1) {
+      for (let i = 0; i < siblings.length; i++) {
+        const sibling = siblings[i];
+
+        if (element === sibling) {
+          return getXPath(parent) + `/${element.tagName.toLowerCase()}[${idx}]`;
+        }
+        if (element.tagName === sibling.tagName) {
+          idx++;
+        }
+      }
+    } else {
+      return getXPath(parent) + `/${element.tagName.toLowerCase()}`;
+    }
+  }
+
+  throw new Error();
+}
 
 function parseHTMLAttributes(element: Element): HTMLAttribute[] {
   const parsedAttributes: HTMLAttribute[] = [
     { name: "tagname", value: element.tagName.toLowerCase() },
+    { name: "xpath", value: getXPath(element) },
   ];
 
   for (let i = 0; i < element.attributes.length; i++) {
@@ -31,7 +69,9 @@ function parseHTMLAttributes(element: Element): HTMLAttribute[] {
       value: attr.value,
     });
   }
-  return parsedAttributes;
+  return parsedAttributes.sort(
+    (a, b) => a.name.charCodeAt(0) - b.name.charCodeAt(0)
+  );
 }
 
 function getFormInputs(): HTMLAttribute[][] {
@@ -41,8 +81,12 @@ function getFormInputs(): HTMLAttribute[][] {
     const elements = document.querySelectorAll(`form ${elementType}`);
 
     for (const element of elements) {
-      const parsedElement = parseHTMLAttributes(element);
-      toeInputs.push(parsedElement);
+      try {
+        const parsedElement = parseHTMLAttributes(element);
+        toeInputs.push(parsedElement);
+      } catch (e) {
+        console.log(e);
+      }
     }
   }
 
@@ -63,25 +107,66 @@ function getCookieInputs(): string[] {
   return cookieInputs;
 }
 
+function getDiffInputs(inputs: ToEInputs): ToEInputs {
+  const diffCookies: string[] = [];
+  const diffFormInputs: HTMLAttribute[][] = [];
+
+  let hash: number;
+  for (const formInput of inputs.forms) {
+    let xpath = "";
+    for (const attr of formInput.slice().reverse()) {
+      if (attr.name === "xpath") {
+        xpath = attr.value;
+        break;
+      }
+    }
+
+    if (xpath !== "") {
+      hash = stringToHash(
+        document.location.hostname +
+          document.location.pathname +
+          document.location.hash +
+          xpath
+      );
+
+      if (fAToEInputs.indexOf(hash) === -1) {
+        fAToEInputs.push(hash);
+        diffFormInputs.push(formInput);
+      }
+    }
+  }
+
+  for (const cookie of inputs.cookies) {
+    hash = stringToHash(document.location.hostname + cookie);
+
+    if (fAToEInputs.indexOf(hash) === -1) {
+      fAToEInputs.push(hash);
+      diffCookies.push(cookie);
+    }
+  }
+
+  return { cookies: diffCookies, forms: diffFormInputs };
+}
+
 export function enumerateInputs(): void {
   const formInputs = getFormInputs();
   const cookieInputs = getCookieInputs();
+  const newInputs = getDiffInputs({ cookies: cookieInputs, forms: formInputs });
 
-  void fetch("${PULUMI_REST_API_URL}", {
-    method: "post",
-    body: JSON.stringify({
-      location: {
-        hash: document.location.hash,
-        host: document.location.hostname,
-        path: document.location.pathname,
-      },
-      inputs: {
-        cookies: cookieInputs,
-        forms: formInputs,
-      },
-    }),
-    headers: { "Content-Type": "application/json" },
-  });
+  if (newInputs.cookies.length > 0 || newInputs.forms.length > 0) {
+    void fetch("${PULUMI_REST_API_URL}", {
+      method: "post",
+      body: JSON.stringify({
+        location: {
+          hash: document.location.hash,
+          host: document.location.hostname,
+          path: document.location.pathname,
+        },
+        inputs: newInputs,
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", enumerateInputs);

--- a/src/tests/enumerator.test.ts
+++ b/src/tests/enumerator.test.ts
@@ -14,7 +14,7 @@ describe("Testing enumerator functions", () => {
       "    </div>" +
       "    <div>" +
       "      <div>" +
-      '        <select name="select1">' +
+      '        <select id="select1" name="select1">' +
       '          <option value="value1">Option 1</option>' +
       '          <option value="value2">Option 2</option>' +
       "        </select>" +
@@ -37,21 +37,28 @@ describe("Testing enumerator functions", () => {
         cookies: ["cookie1", "cookie2", "cookie3"],
         forms: [
           [
-            { name: "tagname", value: "input" },
             { name: "class", value: "class1" },
             { name: "name", value: "input1" },
+            { name: "tagname", value: "input" },
             { name: "type", value: "text" },
             { name: "value", value: "" },
+            { name: "xpath", value: "/html/body[1]/div/form[1]/input[1]" },
           ],
           [
-            { name: "tagname", value: "select" },
+            { name: "id", value: "select1" },
             { name: "name", value: "select1" },
+            { name: "tagname", value: "select" },
+            { name: "xpath", value: "//*[@id='select1']" },
           ],
           [
-            { name: "tagname", value: "textarea" },
             { name: "name", value: "textarea1" },
-            { name: "type", value: "text" },
             { name: "rows", value: "6" },
+            { name: "tagname", value: "textarea" },
+            { name: "type", value: "text" },
+            {
+              name: "xpath",
+              value: "/html/body[1]/div/form[1]/div[1]/textarea",
+            },
           ],
         ],
       },


### PR DESCRIPTION
- Calculate XPath as unique identifier for every input from a form. Do not use the HTML attributes since they may have arbitrary values sometimes and mess the uniqueness.
- Implement differential inputs in SPAs to avoid unnecessary requests.